### PR TITLE
Updated languages e-h to new template

### DIFF
--- a/erlang-beam.md
+++ b/erlang-beam.md
@@ -12,21 +12,34 @@ Erlang is the most prominent of the [BEAM languages](https://github.com/llaisdy/
 
 The Lumen project is endeavoring to create a BEAM runtime and a compiler so that the BEAM applications can be run in a WebAssembly host environment. 
 
-## Uses
-
-The original goal of the Lumen project was to run Elixir in the web browser.
-
-> The primary motivator for Lumen's development was the ability to compile Elixir applications that could target WebAssembly, enabling use of Elixir as a language for frontend development.
-
-We are not clear on whether or not this is possible as of yet.
-
 ## Available Implementations
 
-Lumen is the primary contender, and is interesting because if it is successful we will see support not just for Erlang, but for Elixir and other BEAM languages.
+Lumen is a [compiler and runtime](https://github.com/lumen/lumen).
+
+## Usage
+
+It is not immediately clear what the intended usage pattern for Lumen and WebAssembly is.
+
+## Pros and Cons
+
+Things we like:
+
+- The idea of having both runtime and code compile is cool
+
+Things we're not big fans of:
+
+- We could not immediately figure out exactly how Lumen works, and builds appear to be failing
+- The project might be stalled or unmaintained. It has not been updated in over a year.
+
+
+## Example
+
+>> All of our examples follow [a documented pattern using common tools](/wasm-languages/about-examples).
+
+No example is available at this time.
 
 ## Learn More
 
 Here are some great resources:
 
-- Lumen is a [compiler and runtime](https://github.com/lumen/lumen)
 - Erlang fans may also appreciate [Lunatic](https://lunatic.solutions/), a WebAssembly platform built using an Erlang-style OTP. It will soon support WASI.

--- a/go-lang.md
+++ b/go-lang.md
@@ -12,20 +12,43 @@ Go was early to the WebAssembly game, with the Go compiler producing `wasm32` ou
 But the core Go tools have fallen behind.
 Instead, the alterative Go implementation called [TinyGo](https://tinygo.org/) seems to have taken the lead.
 
-## Uses
-
-TinyGo can compile to `wasm32-wasi`, and TinyGo apps can be run on the Fermyon Platform.
-
 ## Available Implementations
 
 - Go supports browser-based WebAssembly
 - TinyGo supports `wasm32-wasi` as a build target
 - The [Elements compiler](https://www.elementscompiler.com/elements/) may also support compiling browser-oriented Wasm
 
+We have had the best luck with TinyGo.
+
+## Usage
+
+With TinyGo, it is possible to compile _most_ Go code into Wasm with WASI support.
+That means you can write Go code targeting the Fermyon Platform.
+
+## Pros and Cons
+
+
+Things we like:
+
+- TinyGo works very well
+
+Things we're not big fans of:
+
+- Upstream (mainline) Go does not have WASI support
+- TinyGo is still missing (mostly reflection-based) features of Go
+
+
+## Example
+
+>> All of our examples follow [a documented pattern using common tools](/wasm-languages/about-examples).
+
+TinyGo can compile to `wasm32-wasi`, and TinyGo apps can be [run on the Fermyon Platform](https://spin.fermyon.dev/go-components/).
+
 ## Learn More
 
 Here are some great resources:
 
 - TinyGo has [a step-by-step walkthrough](https://tinygo.org/docs/guides/webassembly/) for building and running Go WebAssembly modules
+- There are [instructions](https://spin.fermyon.dev/go-components/) and [examples](https://github.com/fermyon/spin-kitchensink)
 - Get started quickly with [Yo-Wasm](https://github.com/deislabs/yo-wasm), which has support for Go as well as several other languages.
 - A [short article](https://golangbot.com/webassembly-using-go/) on compiling to Go's "JS/Wasm" target

--- a/grain.md
+++ b/grain.md
@@ -11,20 +11,43 @@ author = "Fermyon Staff"
 Grain is a functional programming language that is designed specifically to compile to WebAssembly.
 We have enjoyed using it because of its intuitive syntax and great tooling.
 
+## Available Implementations
 
-## Uses
+There is one official [implementation of Grain](https://grain-lang.org/)
+
+## Usage
 
 Grain can be used in the browser. It also supports WASI, so it can be used for the Fermyon Platform (Wagi and Spin) or with commandline runners like Wasmtime.
 
+## Pros and Cons
 
-## Available Implementations
+Things we like:
 
-Grain has an [official implementation](https://grain-lang.org/) that supports Wasm and WASI out of the box.
+- Easy to learn
+- Good toolchain
+- Good documentation
+
+We're neutral about:
+
+- Compiled object size.
+- Execution speed.
+
+Things we're not big fans of:
+
+- Not a lot of third party libraries yet
+
+
+## Example
+
+>> All of our examples follow [a documented pattern using common tools](/wasm-languages/about-examples).
+
+No examples yet
 
 ## Learn More
 
 Here are some great resources:
 
+- The official [Hello World example](https://grain-lang.org/docs/guide/hello_world)
 - An InfoWorld article [on the basics of Grain](https://www.infoq.com/news/2021/05/grain-web-assembly-first/)
 - An example [Wagi application in Grain](https://github.com/deislabs/hello-wagi-grain)
 - A production-grade [Wagi file server in Grain](https://github.com/deislabs/wagi-fileserver)

--- a/haskell.md
+++ b/haskell.md
@@ -8,16 +8,46 @@ author = "Fermyon Staff"
 ---
 # Haskell in WebAssembly
 
+[Haskell](https://www.haskell.org/) is a purely functional programming language.
+
+## Available Implementations
+
 The Asterius project compiles Haskell to WebAssembly.
 
-## Uses
+## Usage
 
 Asterius targets Node.js and the browser.
 It also appears to support `wasm32-wasi`, though we have not tested it.
 
-## Available Implementations
+## Pros and Cons
 
-- Asterius is the only known implementation of an Haskell-to-WebAssembly compiler.
+<!-- List out some pros and cons of this language vs others WHEN IT COMES TO WASM 
+
+For example, might point out that the Swift runtime requires large binaries or that
+an unofficial implementation lags behind the core language's feature set. Or might
+point out really good tooling or performance.
+
+
+Things we like:
+
+- 
+
+We're neutral about:
+
+- 
+
+Things we're not big fans of:
+
+- 
+-->
+None yet.
+
+
+## Example
+
+>> All of our examples follow [a documented pattern using common tools](/wasm-languages/about-examples).
+
+No example yet.
 
 ## Learn More
 


### PR DESCRIPTION
This updates languages in the E (Erlang) to H (Haskell) range.

Signed-off-by: Matt Butcher <matt.butcher@fermyon.com>