### PR TITLE
docs(*): fix a few typos

### DIFF
--- a/assemblyscript.md
+++ b/assemblyscript.md
@@ -21,7 +21,7 @@ AssemblyScript has an [official implementation](https://www.assemblyscript.org/)
 
 ## Usage
 
-To get started with AssemblyScript, you will need to have a [Node.js environment](https://nodejs.org/en/), indcluding NPM.
+To get started with AssemblyScript, you will need to have a [Node.js environment](https://nodejs.org/en/), including NPM.
 
 From there, you can get started by creating a new Node project.
 

--- a/java.md
+++ b/java.md
@@ -21,7 +21,7 @@ All of the existing Java implementations are browser oriented, and are designed 
 ## Available Implementations
 
 
-- The [Bytecoder project](https://mirkosertic.github.io/Bytecoder/) cross-compiles Java to WebAssembly that can be executed in the browswer
+- The [Bytecoder project](https://mirkosertic.github.io/Bytecoder/) cross-compiles Java to WebAssembly that can be executed in the browser
 - The [TeaVM project](https://teavm.org/) has experimental support for browser-based WebAssembly
 - A dedicate WebAssembly compiler called [JWebAssembly](https://github.com/i-net-software/JWebAssembly) can translate any JVM bytecode to WebAssembly, including Groovy, Clojure, and Kotlin. It, too, is browser-centric.
 - [CheerpJ](https://leaningtech.com/cheerpj/) is much more ambitious, handling the UI as well


### PR DESCRIPTION
Fixes typos as originally PR'd in https://github.com/fermyon/wasm-languages/pull/36.

Thanks again @riffingonsoftware!