### PR TITLE
ruby toml file example is now consistent with dir structure

### DIFF
--- a/ruby.md
+++ b/ruby.md
@@ -129,10 +129,10 @@ trigger = { type = "http", base = "/" }
 files = [
   { source = "lib", destination = "/lib" },
   { source = ".gem", destination = "/.gem" },
-  { source = "ruby/usr", destination = "/usr" },
+  { source = "head-wasm32-unknown-wasi-full/usr", destination = "/usr" },
 ]
 id = "ruby"
-source = "ruby.wasm"
+source = "head-wasm32-unknown-wasi-full/usr/local/bin/ruby"
 [component.trigger]
 executor = { type = "wagi", argv = "${SCRIPT_NAME} -v /lib/hello.rb ${SCRIPT_NAME} ${ARGS}" }
 route = "/"


### PR DESCRIPTION
The ruby tutorial was explicit about the directory structure including head-wasm32-unknown-wasi-full but did not mention renaming and moving of files so as to make it work with the toml file as listed. To help a first time reader of toml understand its various properties, we update it to match the directory structure as described earlier in the tutorial.

Signed-off-by: John-Mason P. Shackelford <jpshack@gmail.com>