### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# CONTRIBUTING
+
+We welcome contributions. To learn more, read the [Contributing guide](https://spin.fermyon.dev/contributing/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # CONTRIBUTING
 
-We welcome contributions. To learn more, read the [Contributing guide](https://spin.fermyon.dev/contributing/).
+We welcome contributions. To learn more, read the [Contributing guide](https://developer.fermyon.com/common/contributing-docs).


### PR DESCRIPTION
This adds a link to the Fermyon documentation contributing guide. We probably should write a separate one for Wasm Languages at some point.

Closes #37