### PR TITLE
Update Kotlin page to reflect recent developments

### DIFF
--- a/kotlin.md
+++ b/kotlin.md
@@ -1,6 +1,6 @@
 date = "2022-01-12T00:23:27Z"
 title = "Kotlin in WebAssembly"
-description = "Kotlin has experimental support for WebAssembly."
+description = "Kotlin support for WebAssembly is in the Alpha stage of development"
 tags = ["kotlin", "jvm", "java", "webassembly"]
 template = "page_lang"
 [extra]
@@ -10,12 +10,13 @@ author = "Fermyon Staff"
 
 Kotlin, like .NET, has an interesting history with WebAssembly.
 
-### Kotlin Native (or Kotlin/Wasm)
+### Kotlin/Wasm
 
-A few years ago, the Kotlin Native team introduced WebAssembly support for the browser.
+A few years ago, the Kotlin team introduced experimental WebAssembly support for the browser: A Kotlin Native `wasm32` LLVM-based compiler target.
 However, in 2019 they began a rewrite of the feature.
 In late 2020, they demoed the upcoming version, called "Kotlin/Wasm".
-In early 2023, the new version reached Beta, but requires the Wasm runtime support the experimental Wasm-GC proposal.
+In early 2023, the new version was released as experimental, and required the Wasm runtime to support the then-experimental Wasm-GC proposal. Kotlin Native `wasm32` target was deprecated.
+In late 2023, Wasm-GC was enabled by default in Chrome and Firefox, and [Kotlin/Wasm went Alpha](https://blog.jetbrains.com/kotlin/2023/12/kotlin-for-webassembly-goes-alpha/).
 
 ### Kotlin on JRE
 
@@ -23,27 +24,27 @@ Kotlin compiled to Java bytecode can be executed by the [Java-to-Webassembly too
 
 ## Uses
 
-In-browser support for Kotlin has been available for a few years.
-The new rewrite, though, is set to replace the older implementation.
-At the time of this writing, KoWasm (see below) has WASI support. But because it still requires the Wasm-GC extension, Spin will not support it until [Wasmtime supports Wasm-GC](https://github.com/bytecodealliance/wasmtime/issues/5032).
+Kotlin/Wasm can be used in browsers.
+At the time of this writing, KoWasm (see below) has WASI support. But because it requires the new Wasm-GC extension, Spin will not support it until [Wasmtime supports Wasm-GC](https://github.com/bytecodealliance/wasmtime/issues/5032).
 Therefore, we do not know whether Kotlin can be used to create Fermyon Cloud applications.
 
 ## Available Implementations
 
-- Kotlin-Native can be compiled to WebAssembly, but this method is going away.
-- The new compiler is [in beta](https://kotlinlang.org/docs/whatsnew-eap.html#new-kotlin-wasm-target), but requires a version of the Wasm runtime that supports (experimental) Wasm Garbage Collection (Wasm-GC).
+- Kotlin/Wasm is [in Alpha](https://kotlinlang.org/docs/whatsnew-eap.html#new-kotlin-wasm-target), but requires a version of the Wasm runtime that supports Wasm Garbage Collection (Wasm-GC).
 - Sebastian Deleuze is working on WASI Kotlin support as [KoWasm](https://github.com/sdeleuze/kowasm).
 
 ## Learn More
 
 Here are some great resources:
 
+- Official [Kotlin/Wasm page](https://kotl.in/wasm)
+- Official [GitHub repository](https://github.com/Kotlin/kotlin-wasm-examples/), containing a collection of examples demonstrating how to use Kotlin with WebAssembly.
 - Sebastian Deleuze's [excellent article](https://seb.deleuze.fr/the-huge-potential-of-kotlin-wasm/) on the potential for Wasm GC and Kotlin (covering Kotlin 1.8.20 Beta)
 - A Feb. 2023 Devclass blog post covering [the new Kotlin Wasm compiler](https://devclass.com/2023/02/14/kotlin-debuts-experimental-kotlin-wasm-target-in-new-beta-a-new-approach-to-frontend-development/)
-- JetBrains' Kotlin and [WebAssembly announcement in Nov. 2021](https://blog.jetbrains.com/kotlin/2021/11/k2-compiler-kotlin-wasm-and-tooling-announcements-at-the-2021-kotlin-event/)
-- A [great blog post](https://superkotlin.com/kotlin-and-webassembly/) on the older way of building Kotlin Wasm binaries.
+- JetBrains' [Kotlin for WebAssembly Goes Alpha](https://blog.jetbrains.com/kotlin/2023/12/kotlin-for-webassembly-goes-alpha/) announcement.
 - The official [preview video](https://www.youtube.com/watch?v=-pqz9sKXatw) of the next-gen Wasm compiler.
 - For the latest feature plan, the [Kotlin Roadmap](https://kotlinlang.org/docs/roadmap.html#roadmap-details) is a good source of information.
     - The key issue is [KT-46773](https://youtrack.jetbrains.com/issue/KT-46773?_gl=1*srzlan*_ga*NzQzMDU1MDYwLjE2NDI1NTgwMDE.*_ga_J6T75801PF*MTY0MjU1ODAwMS4xLjEuMTY0MjU1ODAxNC4w&_ga=2.168897505.1369047405.1642558002-743055060.1642558001)
+    - The WASI support issue is [KT-36172](https://youtrack.jetbrains.com/issue/KT-36172/Support-WASI)
     - The compiler code is [in GitHub](https://github.com/JetBrains/kotlin/tree/master/compiler/ir/backend.wasm/src/org/jetbrains/kotlin/backend/wasm)
 - Wasmtime [tracking issue](https://github.com/bytecodealliance/wasmtime/issues/5032) for Wasm GC

--- a/webassembly-language-support.md
+++ b/webassembly-language-support.md
@@ -19,7 +19,7 @@ This reports on the top 20 languages from [RedMonk's ranking](https://redmonk.co
 Some languages, like CSS, PowerShell, and "Shell", don't really have a meaningful expression in Wasm. However, we have left them here for completeness.
 
 | Language                  | Core  | Browser | WASI | Spin SDK |
-| ------------------------- | ----- | ------- | ---- | -------- |
+|---------------------------| ----- | ------- | ---- | -------- |
 | [JavaScript][JavaScript]  | ✅    | ✅      | ⏳   | ✅       |
 | [Python][Python]          | ✅    | ⏳      | ✅   | ✅       |
 | [Java][Java]              | ✅    | ✅      | ✅   | ⏳       |
@@ -39,7 +39,7 @@ Some languages, like CSS, PowerShell, and "Shell", don't really have a meaningfu
 | [Go][Go]                  | ✅    | ✅      | ✅   | ✅       |
 | [PowerShell][PowerShell]  | ❌    | ❌      | ❌   | ❌       |
 | [Kotlin (JVM)][Kotlin]    | ✅    | ✅      | ✅   | ⏳       |
-| [Kotlin (Native)][Kotlin] | ⏳    | ✅      | ⏳   | ❌       |
+| [Kotlin (Wasm)][Kotlin]   | ⏳    | ✅      | ⏳   | ❌       |
 | [Rust][Rust]              | ✅    | ✅      | ✅   | ✅       |
 | [Dart][Dart]              | ❌    | ⏳      | ❌   | ❌       |
 


### PR DESCRIPTION
Greetings! Thanks a lot for including Kotlin to the language list! A lot of things happed recently around Kotlin and WebAssembly and I'd like to help reflect them on the page:

- Kotlin Native wasm target was officially [removed](https://kotlinlang.org/docs/whatsnew1920.html#change-to-our-target-tiers-policy), and replaced by Kotlin/Wasm
- Wasm-GC spec was [standardized](https://v8.dev/blog/wasm-gc-porting#demo-and-status) in late 2023, and enabled by default in [Chrome](https://developer.chrome.com/blog/wasmgc) and [Firefox](https://www.mozilla.org/en-US/firefox/120.0/releasenotes/)
- Kotlin/Wasm went [Alpha](https://blog.jetbrains.com/kotlin/2023/12/kotlin-for-webassembly-goes-alpha/) in late 2023 (it was never in Beta) 