### PR TITLE
Update markdown files to pass developer build tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 # Fermyon WebAssembly Language Guide
 title = "Readme"
-
 published = false
 
 ---
-This repository contains the Wasm Language Guide from Fermyon.com. You can see the published version at [https://www.fermyon.com/wasm-languages/webassembly-language-support](https://www.fermyon.com/wasm-languages/webassembly-language-support).
+
+- [Fermyon WebAssembly Language Guide](#fermyon-webassembly-language-guide)
+  - [Contributions](#contributions)
+    - [Adding New Languages](#adding-new-languages)
+      - [Examples](#examples)
+    - [Updating Existing Entries](#updating-existing-entries)
+  - [License](#license)
+
+This repository contains the Wasm Language Guide from Fermyon.com. You can see the published version at [https://developer.fermyon.com/wasm-languages/webassembly-language-support](https://developer.fermyon.com/wasm-languages/webassembly-language-support).
 
 The content in this repo (including this page) are formatted to be served directly from [Bartholomew](https://github.com/fermyon/bartholomew).
 

--- a/about-examples.md
+++ b/about-examples.md
@@ -3,11 +3,16 @@ title = "About WebAssembly Examples"
 description = "The WebAssembly examples all follow some common patterns. This page explains them"
 template = "page"
 tags = ["webassembly", "examples"]
-
 [extra]
 author = "Fermyon Staff"  # Use "Fermyon Staff" for general content
 type = "page"
+
 ---
+
+- [The Typical Example](#the-typical-example)
+- [Libraries, SDKs, and Helpers](#libraries-sdks-and-helpers)
+- [Spin Configuration](#spin-configuration)
+- [Wagi Configuration](#wagi-configuration)
 
 The [Fermyon WebAssembly Language Guide](/wasm-languages/webassembly-language-support) tracks languages that can be executed within a WebAssembly runtime. We do our best to keep things consistent across pages. This page explains how we create our examples.
 
@@ -22,10 +27,10 @@ Providing detailed language-specific examples is beyond the scope of the languag
 
 Our canonical example is to build a simple web page that prints `Hello, World` in plain text. In order to serve it as a web page, we try to write the script using one of two tools:
 
-- [Spin](https://spin.fermyon.dev/), a framework for building WebAssembly-based web applications and microservices.
-- [Wagi](https://github.com/deislabs/wagi), used in older content from before Spin was released. All Wagi applications run on Spin (though you must use a `spin.toml` instead of a `modules.toml`)
+- [Spin](https://spin.fermyon.dev/), is a framework for building WebAssembly-based web applications and microservices.
+- [Wagi](https://github.com/deislabs/wagi), is used in older content from before Spin was released. All Wagi applications run on Spin (though you must use a `spin.toml` instead of a `modules.toml`)
 
-For commandline examples, the example runs with [wasmtime](https://wasmtime.dev/), which is committed to implementing the WASI specification.
+For command line examples, the example runs with [wasmtime](https://wasmtime.dev/), which is committed to implementing the WASI specification.
 
 Other runtimes and execution environments are out of the scope of this documentation. However, you may find links to examples in the _Learn More_ section at the bottom of each language page
 

--- a/about-examples.md
+++ b/about-examples.md
@@ -27,8 +27,8 @@ Providing detailed language-specific examples is beyond the scope of the languag
 
 Our canonical example is to build a simple web page that prints `Hello, World` in plain text. In order to serve it as a web page, we try to write the script using one of two tools:
 
-- [Spin](https://spin.fermyon.dev/), is a framework for building WebAssembly-based web applications and microservices.
-- [Wagi](https://github.com/deislabs/wagi), is used in older content from before Spin was released. All Wagi applications run on Spin (though you must use a `spin.toml` instead of a `modules.toml`)
+- [Spin](https://spin.fermyon.dev/), a framework for building WebAssembly-based web applications and microservices.
+- [Wagi](https://github.com/deislabs/wagi), used in older content from before Spin was released. All Wagi applications run on Spin (though you must use a `spin.toml` instead of a `modules.toml`).
 
 For command line examples, the example runs with [wasmtime](https://wasmtime.dev/), which is committed to implementing the WASI specification.
 

--- a/assemblyscript.md
+++ b/assemblyscript.md
@@ -6,7 +6,17 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-03-10T21:50:50Z"
+
 ---
+
+- [AssemblyScript in WebAssembly](#assemblyscript-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+    - [Running in `wasmtime`](#running-in-wasmtime)
+  - [Learn More](#learn-more)
+
 # AssemblyScript in WebAssembly
 
 Inspired by [TypeScript](/wasm-langauges/typescript), AssemblyScript is a strongly typed language. It was written specifically with WebAssembly in mind, and the entire toolchain is oriented around WebAssembly.
@@ -174,10 +184,8 @@ $ npm run asbuild
 > hello@1.0.0 asbuild
 > npm run asbuild:untouched && npm run asbuild:optimized
 
-
 > hello@1.0.0 asbuild:untouched
 > asc assembly/index.ts --target debug
-
 
 > hello@1.0.0 asbuild:optimized
 > asc assembly/index.ts --target release
@@ -201,6 +209,7 @@ drwxr-xr-x  11 technosophos  staff   352B Mar  8 16:07 ..
 
 Map files are for the browser. WAT files are large text file versions of the WebAssembly. The `.wasm` files are the ones we care about. In general, the `optimized.wasm` file is the one we use.
 
+<!-- markdownlint-disable-next-line titlecase-rule -->
 ### Running in `wasmtime`
 
 This is how the module is run in [wasmtime](https://wasmtime.dev/):

--- a/c-lang.md
+++ b/c-lang.md
@@ -6,12 +6,23 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-03-10T21:50:50Z"
+
 ---
+- [C in WebAssembly](#c-in-webassembly)
+  - [Available Implementations](#available-implementations)
+    - [WASI SDK and Clang/LLVM](#wasi-sdk-and-clangllvm)
+    - [Emscripten](#emscripten)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Examples](#examples)
+    - [Compiling C Using the Zig Compiler Toolchain](#compiling-c-using-the-zig-compiler-toolchain)
+  - [Learn More](#learn-more)
+
 # C in WebAssembly
 
 C is a low-level programming language that is typically compiled into a native executable. It is one of the most well-known and frequently used languages.
 
-C is one of the best supported WebAssembly languages. The original developers of WebAssembly had C in mind as a target language, and have put significant work into C support.
+C is one of the best-supported WebAssembly languages. The original developers of WebAssembly had C in mind as a target language, and have put significant work into C support.
 
 Because C++ (aka CPP) is a C language, it is frequently the case that C++ programs can also be compiled to WebAssembly. In addition to this document, there is also a WebAssembly Language Support page [specifically for C++](/wasm-languages/cpp).
 
@@ -43,7 +54,7 @@ While C is a low-level language, not all of the `stdlib` is supported by WebAsse
 
 It is good to be familiar with both [WASI](https://wasi.dev) and the WebAssembly runtime's host extensions when writing or porting C or C++ code.
 
-## Pros an Cons
+## Pros and Cons
 
 Things we like about C/C++ as a WebAssembly language:
 
@@ -128,7 +139,7 @@ $ curl localhost:3000
 Hello, World
 ```
 
-### Compiling C using the Zig compiler toolchain
+### Compiling C Using the Zig Compiler Toolchain
 
 Users have reported that it is easier to compile C programs with Zig. With Zig, you will not need to separately install the WASI SDK, as it is included with the toolchain.
 
@@ -150,7 +161,7 @@ To compile with Zig, use a `zig build-exe` with the `-lc` ("library C") flag:
 $ zig build-exe -O ReleaseSmall -target wasm32-wasi hello.c -lc
 ```
 
-Now the `hello.wasm` can be run in `wasmtime` or `spin`.
+Now the `hello.wasm` can be run in `wasmtime` or `spin`:
 
 ```console
 $ wasmtime hello.wasm

--- a/c-sharp.md
+++ b/c-sharp.md
@@ -6,7 +6,15 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-03-10T21:50:50Z"
+
 ---
+
+- [C# and .NET in WebAssembly](#c-and-net-in-webassembly)
+	- [Available Implementations](#available-implementations)
+	- [Pros and Cons](#pros-and-cons)
+	- [Example](#example)
+	- [Learn More](#learn-more)
+
 # C# and .NET in WebAssembly
 
 The .NET (aka dotnet) ecosystem supports a variety of languages, including C# (C sharp) and ASP.NET. Programs that target .NET are compiled to an intermediary bytecode format that runs in the .NET Common Language Runtime (CLR). This makes .NET an example of a [virtual machine language](/blog/scripts-vs.compiled-wasm.md).

--- a/clojure.md
+++ b/clojure.md
@@ -6,7 +6,13 @@ template = "page_lang"
 
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Clojure in WebAssembly](#clojure-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Learn More](#learn-more)
+
 # Clojure in WebAssembly
 
 Clojure is a functional programming language that is part of the Java/JVM ecosystem.

--- a/cobol.md
+++ b/cobol.md
@@ -6,7 +6,15 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-03-10T21:50:50Z"
+
 ---
+
+- [COBOL in WebAssembly](#cobol-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Example](#example)
+  - [Pros and Cons](#pros-and-cons)
+  - [Learn More](#learn-more)
+
 # COBOL in WebAssembly
 
 That venerable business language of the pre-2000 era is back. COBOL can be compiled to WebAssembly. We are not entirely sure, given the [blog's date](https://blog.cloudflare.com/cloudflare-workers-now-support-cobol/) whether this was originally an April Fool's Day joke. But... it does appear to work. This project has since been renamed to Cobweb.

--- a/cpp.md
+++ b/cpp.md
@@ -6,7 +6,15 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-03-10T21:50:50Z"
+
 ---
+
+- [C++ in WebAssembly](#c-in-webassembly)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Examples](#examples)
+  - [Learn More](#learn-more)
+
 # C++ in WebAssembly
 
 C++ support for WebAssembly is handled by the [C language support](/wasm-languages/c-lang). And C language support is currently excellent.

--- a/dart.md
+++ b/dart.md
@@ -6,7 +6,14 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2023-10-26T00:50:50Z"
+
 ---
+
+- [Dart in WebAssembly](#dart-in-webassembly)
+  - [Pros and Cons](#pros-and-cons)
+  - [Examples](#examples)
+  - [Learn More](#learn-more)
+
 # Dart in WebAssembly
 
 Dart is a programming language designed for client development. The Dart team is

--- a/erlang-beam.md
+++ b/erlang-beam.md
@@ -5,7 +5,16 @@ tags = ["language", "webassembly", "beam", "erlang", "elixir"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Erlang in WebAssembly](#erlang-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Erlang in WebAssembly
 
 Erlang is the most prominent of the [BEAM languages](https://github.com/llaisdy/beam_languages). Elixir is another popular BEAM language.
@@ -30,7 +39,6 @@ Things we're not big fans of:
 
 - We could not immediately figure out exactly how Lumen works, and builds appear to be failing
 - The project might be stalled or unmaintained. It has not been updated in over a year.
-
 
 ## Example
 

--- a/go-lang.md
+++ b/go-lang.md
@@ -5,7 +5,16 @@ tags = ["go", "golang", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Go in WebAssembly](#go-in-webassembly)
+	- [Available Implementations](#available-implementations)
+	- [Usage](#usage)
+	- [Pros and Cons](#pros-and-cons)
+	- [Example](#example)
+	- [Learn More](#learn-more)
+
 # Go in WebAssembly
 
 Go was early to the WebAssembly game, with the Go compiler producing `wasm32` output alongside its regularly supported build targets.
@@ -27,7 +36,6 @@ That means you can write Go code targeting the Fermyon Platform.
 
 ## Pros and Cons
 
-
 Things we like:
 
 - TinyGo works very well
@@ -41,7 +49,6 @@ Things we're not big fans of:
 
 - Upstream (mainline) Go does not have WASI support
 - TinyGo is still missing (mostly reflection-based) features of Go
-
 
 ## Example
 

--- a/grain.md
+++ b/grain.md
@@ -5,7 +5,16 @@ tags = ["grain", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Grain in WebAssembly](#grain-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Grain in WebAssembly
 
 Grain is a functional programming language that is designed specifically to compile to WebAssembly.
@@ -35,7 +44,6 @@ We're neutral about:
 Things we're not big fans of:
 
 - Not a lot of third party libraries yet
-
 
 ## Example
 
@@ -79,7 +87,6 @@ executor = { type = "wagi" }
 ```
 
 From there, you can use `spin up` to start a server, and see the results on `http://localhost:3000`.
-
 
 ## Learn More
 

--- a/haskell.md
+++ b/haskell.md
@@ -5,7 +5,16 @@ tags = ["haskell", "webassembly", "asterius"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Haskell in WebAssembly](#haskell-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Haskell in WebAssembly
 
 [Haskell](https://www.haskell.org/) is a purely functional programming language.

--- a/index.md
+++ b/index.md
@@ -8,6 +8,10 @@ author = "Fermyon Staff"
 
 ---
 
+- [Guide to WebAssembly Languages](#guide-to-webassembly-languages)
+  - [Help Us Stay Current](#help-us-stay-current)
+  - [Adding Your Language to the Matrix](#adding-your-language-to-the-matrix)
+
 # Guide to WebAssembly Languages
 
 A wide variety of languages can be compiled to WebAssembly. Our programming language guide focuses on the top 20 programming languages. It also covers interesting programming languages as well as programming languages written specifically for WebAssembly.

--- a/java.md
+++ b/java.md
@@ -5,7 +5,14 @@ tags = ["java", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Java in WebAssembly](#java-in-webassembly)
+  - [Uses](#uses)
+  - [Available Implementations](#available-implementations)
+  - [Learn More](#learn-more)
+
 # Java in WebAssembly
 
 Many exciting WebAssembly things are happening in the Java ecosystem.
@@ -24,7 +31,6 @@ There is a working [Wasm plus WASI version of TeaVM](https://github.com/fermyon/
 
 Here's a detailed video by Joel Dice:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/MFruf7aqcbE?si=tAdqWPq1W7LqvT0p" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
-
 
 - The [Bytecoder project](https://mirkosertic.github.io/Bytecoder/) cross-compiles Java to WebAssembly that can be executed in the browser
 - The [TeaVM project](https://teavm.org/) has experimental support for browser-based WebAssembly

--- a/javascript.md
+++ b/javascript.md
@@ -2,14 +2,17 @@ date = "2022-01-11T21:06:42Z"
 title = "JavaScript in WebAssembly"
 description = "JavaScript can be compiled to WebAssembly. There are even multiple implementations of JavaScript WebAssembly runtimes."
 template = "page_lang"
-
-# Most important first
 tags = ["javascript","webassembly"]
-
 [extra]
 author = "Fermyon Staff"
-# author_page = "/author/"
+
 ---
+
+- [JavaScript in WebAssembly](#javascript-in-webassembly)
+  - [Uses](#uses)
+  - [Available JavaScript Implementations](#available-javascript-implementations)
+  - [Learn More](#learn-more)
+
 # JavaScript in WebAssembly
 
 Compiling JavaScript to WebAssembly is different than using JavaScript to talk to a WebAssembly module.

--- a/kotlin.md
+++ b/kotlin.md
@@ -5,7 +5,16 @@ tags = ["kotlin", "jvm", "java", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Kotlin in WebAssembly](#kotlin-in-webassembly)
+    - [Kotlin/Wasm](#kotlinwasm)
+    - [Kotlin on JRE](#kotlin-on-jre)
+  - [Uses](#uses)
+  - [Available Implementations](#available-implementations)
+  - [Learn More](#learn-more)
+
 # Kotlin in WebAssembly
 
 Kotlin, like .NET, has an interesting history with WebAssembly.

--- a/lisp.md
+++ b/lisp.md
@@ -3,10 +3,16 @@ title = "Lisp in WebAssembly"
 description = "Lisp can be compiled to WebAssembly."
 tags = ["language", "webassembly"]
 template = "page_lang"
-
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Lisp in WebAssembly](#lisp-in-webassembly)
+  - [Uses](#uses)
+  - [Available Implementations](#available-implementations)
+  - [Learn More](#learn-more)
+
 # Lisp in WebAssembly
 
 The famous functional programming language Lisp has some interesting properties that has intrigued developers. A few projects are work-in-progress ports of Lisp in WebAssembly. Nothing appears to be production-ready yet, but the progress is promising.

--- a/lua.md
+++ b/lua.md
@@ -5,7 +5,16 @@ tags = ["lua", "language", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Lua in WebAssembly](#lua-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Lua in WebAssembly
 
 [Lua](https://www.lua.org/) is a lightweight scripting language designed to be easily embedded. It enjoys broad usage as a plugin-and-extension language, and has a large ecosystem. But it is not generally considered one of the top programming languages.

--- a/motoko.md
+++ b/motoko.md
@@ -5,7 +5,14 @@ tags = ["motoko", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Motoko in WebAssembly](#motoko-in-webassembly)
+  - [Uses](#uses)
+  - [Available Implementations](#available-implementations)
+  - [Learn More](#learn-more)
+
 # Motoko in WebAssembly
 
 Motoko is a high-level programming language that is designed for writing Internet Computer canisters. It leverages a simple design for everyday programmers and supports an underlying Wasm and IC execution model. 

--- a/objective-c.md
+++ b/objective-c.md
@@ -5,7 +5,11 @@ tags = ["objective-c", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Objective-C in WebAssembly](#objective-c-in-webassembly)
+
 # Objective-C in WebAssembly
 
 It seems like Objective-C to WebAssembly should be possible in no small part because of LLVM.

--- a/perl.md
+++ b/perl.md
@@ -6,7 +6,15 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2023-10-26T00:50:50Z"
+
 ---
+
+- [Perl in WebAssembly](#perl-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Learn More](#learn-more)
+
 # Perl in WebAssembly
 
 Perl (Practical Extraction and Reporting Language) was the _lingua franca_ of the early web.
@@ -44,7 +52,6 @@ Things we're not big fans of:
 
 - It runs only in the browser
 - The project seems to be stagnant
-
 
 ## Learn More
 

--- a/php.md
+++ b/php.md
@@ -5,7 +5,14 @@ tags = ["PHP", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [PHP in WebAssembly](#php-in-webassembly)
+  - [Uses](#uses)
+  - [Available Implementations](#available-implementations)
+  - [Learn More](#learn-more)
+
 # PHP in WebAssembly
 
 PHP is a popular web scripting language.
@@ -26,7 +33,6 @@ access to a database (SQLite) and file system access.
 - The original version of PHP-In-Browser (PIB) was [Oraoto's version](https://oraoto.github.io/pib/)
 - Another version of PIB is [Soyuka's fork](https://github.com/soyuka/php-wasm)
 - [`wasm32-wasi` PHP releases](https://github.com/vmware-labs/webassembly-language-runtimes/releases?q=php&expanded=true) provided by the Wasm Labs team at VMware
-
 
 ## Learn More
 

--- a/powershell.md
+++ b/powershell.md
@@ -5,7 +5,12 @@ tags = ["powershell", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [PowerShell and WebAssembly](#powershell-and-webassembly)
+  - [Learn More](#learn-more)
+
 # PowerShell and WebAssembly
 
 PowerShell is consistently ranked among the top programming languages.

--- a/prolog.md
+++ b/prolog.md
@@ -3,10 +3,18 @@ title = "Prolog in WebAssembly"
 description = "Prolog can be compiled to WebAssembly, and there are many supporting projects."
 tags = ["language", "webassembly"]
 template = "page_lang"
-
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Prolog in WebAssembly](#prolog-in-webassembly)
+	- [Available Implementations](#available-implementations)
+	- [Usage](#usage)
+	- [Pros and Cons](#pros-and-cons)
+	- [Example](#example)
+	- [Learn More](#learn-more)
+
 # Prolog in WebAssembly
 
 <!--
@@ -62,7 +70,6 @@ Things we like:
 
 - It is super easy to use
 - [A Spin SDK!](https://github.com/guregu/trealla-spin)
-
 
 ## Example
 

--- a/python.md
+++ b/python.md
@@ -6,14 +6,21 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2023-10-26T00:50:50Z"
+
 ---
+
+- [Python in WebAssembly](#python-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Python in WebAssembly
 
 Python is one of the most popular programming languages in the world, and its WebAssembly implementation seems to be coming along quickly.
 While it is not yet ready for use, we anticipate it will be functional in the first half of 2022.
 
 The most momentum is in the CPython community, which is approaching both Emscripten-based and WASI-based implementations.
-
 
 ## Available Implementations
 
@@ -72,7 +79,6 @@ The file `app.wasm` contains both the interpreter (in an initialized state) and 
 $ ls -lah app.wasm
 -rw-r--r--  1 technosophos  staff    24M Oct 26 18:22 app.wasm
 ```
-
 
 ## Learn More
 

--- a/r-lang.md
+++ b/r-lang.md
@@ -6,7 +6,12 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-02-17T16:55:42Z"
+
 ---
+
+- [R in WebAssembly](#r-in-webassembly)
+  - [Learn More](#learn-more)
+
 # R in WebAssembly
 
 R is a popular statistics-oriented language. An in-browser version of the language is now in development. This version patches the official R repository and adds browser tooling. We are unsure whether this version of R can be run in standalone WebAssembly runtimes like Wasmtime or Wamr.

--- a/ruby.md
+++ b/ruby.md
@@ -5,7 +5,16 @@ tags = ["ruby", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Ruby in WebAssembly](#ruby-in-webassembly)
+- [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Ruby in WebAssembly
 
 Ruby is one of the most popular scripting languages.
@@ -63,7 +72,6 @@ We're neutral about:
 Things we're not big fans of:
 
 - At this stage, users of the Wasm version will need to understand how Ruby loads its dependencies
-
 
 ## Example
 

--- a/rust.md
+++ b/rust.md
@@ -5,7 +5,17 @@ tags = ["rust", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Rust in WebAssembly](#rust-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+    - [Writing Wagi-based Rust Apps](#writing-wagi-based-rust-apps)
+  - [Learn More](#learn-more)
+
 # Rust in WebAssembly
 
 Rust is probably the best supported language of the WebAssembly ecosystem.
@@ -47,11 +57,9 @@ Things we like:
 - Thanks to Cargo's flexible build system, some crates even have special feature flags to enable Wasm features (e.g. Chrono)
 - Because of Rust's memory management techniques, Rust binary sizes are small compared to similar languages
 
-
 Things we're not big fans of:
 
 - Many Rust libraries do not work with Wasm. Most notably, anything that uses Tokio or `async` does not yet work.
-
 
 ## Example
 

--- a/scala.md
+++ b/scala.md
@@ -5,7 +5,11 @@ tags = ["scala", "java", "kotlin", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Scala in WebAssembly](#scala-in-webassembly)
+
 # Scala in WebAssembly
 
 Like Kotlin, Scala began as a JVM-specific language and has moved toward other backends like LLVM.

--- a/shell.md
+++ b/shell.md
@@ -3,10 +3,16 @@ title = "Shell in WebAssembly"
 description = "Various projects are implementing shell-like implementations in WebAssembly"
 tags = ["shell", "bash", "sh", "csh", "unix"]
 template = "page_lang"
-
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Shell in WebAssembly](#shell-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Learn More](#learn-more)
+
 # Shell in WebAssembly
 
 "Shell" refers to the class of UNIX-like languages that are designed for interactive prompts and shell scripts.

--- a/standards.md
+++ b/standards.md
@@ -6,7 +6,14 @@ template = "page_lang"
 [extra]
 author = "Fermyon Staff"
 last_modified = "2022-07-25T21:50:50Z"
+
 ---
+
+- [WebAssembly Standard and W3 Working Group](#webassembly-standard-and-w3-working-group)
+- [WebAssembly System Interface (WASI)](#webassembly-system-interface-wasi)
+  - [The Component Model](#the-component-model)
+- [WebAssembly Gateway Interface (Wagi)](#webassembly-gateway-interface-wagi)
+- [Spin Improvement Proposals (SIPs)](#spin-improvement-proposals-sips)
 
 This page tracks WebAssembly standards along with useful resources for understanding those standards or getting involved.
 

--- a/swift.md
+++ b/swift.md
@@ -5,7 +5,17 @@ tags = ["swift", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Swift in WebAssembly](#swift-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+    - [Optimizing](#optimizing)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+
 # Swift in WebAssembly
 
 Swift is a popular language in the Apple ecosystem.
@@ -17,7 +27,7 @@ destined either for the browser or for a WASI environment.
 
 The [SwiftWasm](https://swiftwasm.org/) project compiles Swift to WebAssembly. While this is a community-led project, the [stated goal](https://book.swiftwasm.org/index.html) of the project is:
 
-> [T]o fully support the WebAssembly target for Swift and to be merged into the upstream repository.
+> To fully support the WebAssembly target for Swift and to be merged into the upstream repository.
 
 It works like a drop-in replacement to the standard Swift tools.
 
@@ -58,7 +68,6 @@ We're neutral about:
 Things we're not big fans of:
 
 - There is no Windows support
-
 
 ## Example
 

--- a/swift.md
+++ b/swift.md
@@ -27,7 +27,7 @@ destined either for the browser or for a WASI environment.
 
 The [SwiftWasm](https://swiftwasm.org/) project compiles Swift to WebAssembly. While this is a community-led project, the [stated goal](https://book.swiftwasm.org/index.html) of the project is:
 
-> To fully support the WebAssembly target for Swift and to be merged into the upstream repository.
+> [T]o fully support the WebAssembly target for Swift and to be merged into the upstream repository.
 
 It works like a drop-in replacement to the standard Swift tools.
 

--- a/tpl.md
+++ b/tpl.md
@@ -3,13 +3,12 @@ title = "Python in WebAssembly"
 description = "can be compiled to WebAssembly."
 tags = ["language", "webassembly"]
 template = "page_lang"
-
-# DELETE THIS LINE before opening a PR
 published = false
-
 [extra]
 author = "Fermyon Staff"
+
 ---
+
 # $ in WebAssembly
 
 <!--

--- a/tpl.md
+++ b/tpl.md
@@ -3,13 +3,16 @@ title = "Python in WebAssembly"
 description = "can be compiled to WebAssembly."
 tags = ["language", "webassembly"]
 template = "page_lang"
+<!---
+Delete the published = false line below before creating the PR
+-->
 published = false
 [extra]
 author = "Fermyon Staff"
 
 ---
 
-# $ in WebAssembly
+# X in WebAssembly
 
 <!--
 A sentence or two about the language. Make sure to say whether it is scripting, compiled, etc.

--- a/typescript.md
+++ b/typescript.md
@@ -5,7 +5,12 @@ tags = ["typescript", "javascript", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [TypeScript in WebAssembly](#typescript-in-webassembly)
+  - [Learn More](#learn-more)
+
 # TypeScript in WebAssembly
 
 TypeScript is a popular language in its own right, but it is a very near relative of JavaScript.
@@ -13,7 +18,6 @@ In fact, most of the time, TS code is converted to JavaScript during the develop
 As such, the best approach to using TypeScript in WebAssembly is to convert it and [use JavaScript tools](/wasm-languages/javascript).
 
 Another potential solution is to [use AssemblyScript](/wasm-languages/assemblyscript), a subset of TypeScript tooled specifically for WebAssembly.
-
 
 ## Learn More
 

--- a/webassembly-language-support.md
+++ b/webassembly-language-support.md
@@ -2,14 +2,18 @@ date = "2022-01-11T20:08:47Z"
 title = "WebAssembly Language Support Matrix"
 description = "Tracking the programming languages that compile to WebAssembly (Wasm). This page stays up to date with information about which languages can compile to Wasm, and what their language characteristics are."
 template = "page"
-
-# Most important first
 tags = ["webassembly", "programming languages", "javascript", "python", "rust", "dotnet", "ruby"]
-
 [extra]
 author = "Fermyon Staff"
-# author_page = "/author/"
+
 ---
+
+- [WebAssembly Support in Top 20 Languages](#webassembly-support-in-top-20-languages)
+- [WebAssembly Specific Languages](#webassembly-specific-languages)
+- [Other Notable Languages](#other-notable-languages)
+- [How To Read These Charts](#how-to-read-these-charts)
+- [Updates and Additions](#updates-and-additions)
+- [Relevant Standards](#relevant-standards)
 
 This guide tracks support for compiling a language to WebAssembly. It is organized into three sections: Support for the top 20 languages, WebAssembly-specific languages, and other notable languages. We track whether the language can be compiled to run in the browser, in other non-browser environments, and in a [WASI](https://wasi.dev) environment. In the detail page for each language, we do our best to not only state the current level of support, but also point to an array of useful resources.
 

--- a/zig.md
+++ b/zig.md
@@ -5,7 +5,17 @@ tags = ["zig", "webassembly"]
 template = "page_lang"
 [extra]
 author = "Fermyon Staff"
+
 ---
+
+- [Zig in WebAssembly](#zig-in-webassembly)
+  - [Available Implementations](#available-implementations)
+  - [Usage](#usage)
+  - [Pros and Cons](#pros-and-cons)
+  - [Example](#example)
+  - [Learn More](#learn-more)
+  - [Learn More](#learn-more-1)
+
 # Zig in WebAssembly
 
 Zig, a systems language, has official support for WebAssembly.


### PR DESCRIPTION
We are now hosting the wasm-languages repository as part of developer documentation site which has a strict build/test routine. This PR addresses errors such as title case, spare line spacing and other small nits that stop the CI from completing over on Fermyon Developer Home.