### PR TITLE
Add message to redirect users to the new location of the wasm-languages markdown files and public-facing website.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Update 20th February 2024:**
 
-This repository is archived, and all contribution activity now takes place in markdown files at [https://github.com/fermyon/developer/wasm-languages](https://github.com/fermyon/developer/wasm-languages).
+This repository is archived, and all contribution activity now takes place in the [fermyon/developer repository](https://github.com/fermyon/developer/tree/main/content/wasm-languages).
 
 The public-facing website (that renders these markdown files) is at [https://developer.fermyon.com/wasm-languages](https://developer.fermyon.com/wasm-languages).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Fermyon WebAssembly Language Guide
-title = "Readme"
 
-published = false
+**Update 20th February 2024:**
+
+This repository is archived, and all contribution activity now takes place in markdown files at [https://github.com/fermyon/developer/wasm-languages](https://github.com/fermyon/developer/wasm-languages).
+
+The public-facing website (that renders these markdown files) is at [https://developer.fermyon.com/wasm-languages](https://developer.fermyon.com/wasm-languages).
 
 ---
 This repository contains the Wasm Language Guide from Fermyon.com. You can see the published version at [https://www.fermyon.com/wasm-languages/webassembly-language-support](https://www.fermyon.com/wasm-languages/webassembly-language-support).


### PR DESCRIPTION
Signed-off-by: tpmccallum tim.mccallum@fermyon.com